### PR TITLE
chore: Improve IO and fragment logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.100"
 argh = "0.1.13"
 colored = "3.0.0"
 imap-codec = "2.0.0-alpha.6"
-imap-next = { version = "0.3.1", features = ["ext_id"] }
+imap-next = { version = "0.3.3", features = ["ext_id"] }
 once_cell = "1.21.3"
 rustls-native-certs = "0.8.2"
 rustls-pemfile = "2.2.0"

--- a/README.md
+++ b/README.md
@@ -61,10 +61,16 @@ RUST_LOG=imap_proxy=trace cargo run
 You should probably experiment with the environment variable. For example, you can use ...
 
 ```sh
+RUST_LOG=imap_proxy=trace,imap_next=trace cargo run
+```
+
+... to enable additional logs for the "imap-next" module. This way, you will get IO and fragment events. And you can use ...
+
+```sh
 RUST_LOG=trace cargo run
 ```
 
-... to enable logs from lower libraries. This way, you will get TLS events and `io/{read,write}/raw` events.
+... to enable logs from all lower libraries. This way, you will get also TLS events.
 
 ```mermaid  
 graph LR;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -312,8 +312,8 @@ fn handle_client_event(
     };
 
     match event {
-        server::Event::GreetingSent { .. } => {
-            trace!(role = "p2c", "<--- greeting");
+        server::Event::GreetingSent { greeting } => {
+            trace!(role = "p2c", ?greeting, "<---");
         }
         server::Event::ResponseSent { handle, .. } => {
             trace!(role = "p2c", ?handle, "<---");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -194,8 +194,8 @@ impl Proxy<ConnectedState> {
             Client::new(options)
         };
         let mut proxy_to_server_stream = self.state.proxy_to_server;
-        let stream_event = server_span
-            .in_scope(|| proxy_to_server_stream.next(&mut proxy_to_server))
+        let stream_event = proxy_to_server_stream
+            .next(&mut proxy_to_server)
             .instrument(server_span.clone())
             .await;
         let Some(server_event) = handle_stream_event("s2p", stream_event) else {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -185,8 +185,8 @@ impl State for ConnectedState {}
 
 impl Proxy<ConnectedState> {
     pub async fn start_conversation(self) {
-        let client_span = info_span!("proxy", side = "client");
-        let server_span = info_span!("proxy", side = "server");
+        let client_span = info_span!("proxy", with = "client");
+        let server_span = info_span!("proxy", with = "server");
 
         let mut proxy_to_server = {
             let mut options = client::Options::default();


### PR DESCRIPTION
Add fragment logging and improve IO logging.

First we need a need to merge https://github.com/duesee/imap-next/pull/311 and create a new release.

When running `RUST_LOG=imap_proxy=trace,imap_next=trace cargo run`, the conversation ...

```
S: * OK ...\r\n
C: A1 LOGIN {5}\r\n
S: + ...
C: ABCDE {5}\r\n
S: + ...
C: FGHIJ\r\n
S: A1 NO ...\r\n
```

... will produce these logs:

```
# Test
imap://127.0.0.1:1143 (insecure) -> imap://127.0.0.1:1144 (insecure)

 INFO service{name="Test"}: Bound to bind_addr_port="127.0.0.1:1143"
 INFO service{name="Test"}: Accepted client client_addr=127.0.0.1:56116
 INFO service{name="Test"}:client{addr=127.0.0.1:56116}: Connecting to server server_addr_port="127.0.0.1:1144"
 INFO service{name="Test"}:client{addr=127.0.0.1:56116}: Connected to server server_addr_port="127.0.0.1:1144"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="read"}: data="* OK ...\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="read"}: type=Line data="* OK ...\\n" complete=true exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: <--| role="s2p" greeting=Greeting { kind: Ok, code: None, text: Text("...") }
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="write"}: type=Line data="* OK ...\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="write"}: data="* OK ...\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: <--- greeting role="p2c"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="read"}: data="A1 LOGIN {5}\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="read"}: type=Line data="A1 LOGIN {5}\\n" complete=false exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="write"}: type=Line data="+ proxy: Literal accepted by proxy\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="write"}: data="+ proxy: Literal accepted by proxy\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="read"}: data="ABCDE {5}\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="read"}: type=Literal data="ABCDE" complete=false exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="read"}: type=Line data=" {5}\\n" complete=false exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="write"}: type=Line data="+ proxy: Literal accepted by proxy\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="write"}: data="+ proxy: Literal accepted by proxy\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="read"}: data="FGHIJ\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="read"}: type=Literal data="FGHIJ" complete=false exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="read"}: type=Line data="\\n" complete=true exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: |--> role="c2p" command=Command { tag: Tag("A1"), body: Login { username: String(Literal(Literal { data: b"ABCDE", mode: Sync })), password: String(Literal(Literal { data: b"FGHIJ", mode: Sync })) } }
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: enqueue_command role="p2s" handle=CommandHandle(0, 0)
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="write"}: type=Line data="A1 LOGIN {5}\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="write"}: data="A1 LOGIN {5}\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="read"}: data="+ ...\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="read"}: type=Line data="+ ...\\n" complete=true exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="write"}: type=Literal data="ABCDE"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="write"}: type=Line data=" {5}\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="write"}: data="ABCDE {5}\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="read"}: data="+ ...\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="read"}: type=Line data="+ ...\\n" complete=true exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="write"}: type=Literal data="FGHIJ"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="write"}: type=Line data="\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="write"}: data="FGHIJ\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: ---> role="p2s" handle=CommandHandle(0, 0)
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:io{action="read"}: data="A1 NO ...\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="server"}:fragment{action="read"}: type=Line data="A1 NO ...\\n" complete=true exceeded=false poisoned=false
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: <--| role="s2p" status=Tagged(Tagged { tag: Tag("A1"), body: StatusBody { kind: No, code: None, text: Text("...") } })
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: enqueue_status role="p2c" handle=ResponseHandle(0, 0)
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:fragment{action="write"}: type=Line data="A1 NO ...\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}:proxy{side="client"}:io{action="write"}: data="A1 NO ...\\r\\n"
TRACE service{name="Test"}:client{addr=127.0.0.1:56116}: <--- role="p2c" handle=ResponseHandle(0, 0)
```